### PR TITLE
feat: new wit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,7 +711,7 @@ dependencies = [
 
 [[package]]
 name = "segment-component"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "segment-component"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ This component implements the data collection protocol between [Edgee](https://w
 3. Add the following configuration to your `edgee.toml`:
 
 ```toml
-[[destinations.data_collection]]
-name = "segment"
-component = "/var/edgee/components/segment.wasm"
-credentials.segment_api_key = "..."
+[[components.data_collection]]
+id = "segment"
+file = "/var/edgee/components/segment.wasm"
+settings.segment_api_key = "..."
 ```
 
 ## Event Handling
@@ -48,22 +48,22 @@ This allows the user's data to be added to any subsequent page or follow-up call
 
 ### Basic Configuration
 ```toml
-[[destinations.data_collection]]
-name = "segment"
-component = "/var/edgee/components/segment.wasm"
-credentials.segment_api_key = "..."
+[[components.data_collection]]
+id = "segment"
+file = "/var/edgee/components/segment.wasm"
+settings.segment_api_key = "..."
 
 # Optional configurations
-config.anonymization = true        # Enable/disable data anonymization in case of pending or denied consent
-config.default_consent = "pending" # Set default consent status if not specified by the user
+settings.edgee_anonymization = true        # Enable/disable data anonymization in case of pending or denied consent
+settings.edgee_default_consent = "pending" # Set default consent status if not specified by the user
 ```
 
 ### Event Controls
 Control which events are forwarded to Segment:
 ```toml
-config.page_event_enabled = true   # Enable/disable page event
-config.track_event_enabled = true  # Enable/disable track event
-config.user_event_enabled = true   # Enable/disable user event
+settings.edgee_page_event_enabled = true   # Enable/disable page event
+settings.edgee_track_event_enabled = true  # Enable/disable track event
+settings.edgee_user_event_enabled = true   # Enable/disable user event
 ```
 
 ### Consent Management

--- a/src/segment_payload.rs
+++ b/src/segment_payload.rs
@@ -30,13 +30,13 @@ pub(crate) struct SegmentPayload {
 }
 
 impl SegmentPayload {
-    pub fn new(edgee_event: &Event, cred_map: &Dict, event_type: String) -> anyhow::Result<Self> {
+    pub fn new(edgee_event: &Event, settings: &Dict, event_type: String) -> anyhow::Result<Self> {
         let mut segment_payload = SegmentPayload {
             event_type,
             ..SegmentPayload::default()
         };
 
-        let credentials: HashMap<String, String> = cred_map
+        let credentials: HashMap<String, String> = settings
             .iter()
             .map(|(key, value)| (key.to_string(), value.to_string()))
             .collect();

--- a/wit/deps.lock
+++ b/wit/deps.lock
@@ -1,4 +1,4 @@
 [protocols]
-url = "https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.3.0.tar.gz"
-sha256 = "4d412367fff6f826280acbe95f7067e362d9299d76e60994981e7e27c74d1576"
-sha512 = "65021cace5ed07990fdfb563699accb975a31cb22311739ff6189849b969b06b564a0f8f72de154fd086ba474757d3cffaef0175778e4989c467280cf1c86284"
+url = "https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.4.0.tar.gz"
+sha256 = "8b5c8ea97c81d1d6cf4f227e75afb8c4dc5c0a411c3a0401fb7e4f7b745e21ba"
+sha512 = "16771cd12095409e7c4857a8f5c0b4ad680959e3c35dcd7999e11131bcce05d3b1a1b829daefceabbd853ae5b7f6453e3e359ddfbdebd6e2a94db6c55780368f"

--- a/wit/deps.toml
+++ b/wit/deps.toml
@@ -1,1 +1,1 @@
-protocols="https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.3.0.tar.gz"
+protocols="https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.4.0.tar.gz"

--- a/wit/deps/protocols/consent-mapping.wit
+++ b/wit/deps/protocols/consent-mapping.wit
@@ -1,7 +1,7 @@
 package edgee:protocols;
 
 interface consent-mapping {
-    type config = list<tuple<string,string>>;
+    type dict = list<tuple<string,string>>;
 
     enum consent {
         pending,
@@ -9,5 +9,5 @@ interface consent-mapping {
         denied,
     }
 
-    map: func(cookie: string, config: config) -> option<consent>;
+    map: func(cookie: string, settings: dict) -> option<consent>;
 }

--- a/wit/deps/protocols/data-collection.wit
+++ b/wit/deps/protocols/data-collection.wit
@@ -102,12 +102,13 @@ interface data-collection {
         method: http-method,
         url: string,
         headers: dict,
+        forward-client-headers: bool,
         body: string,
     }
 
     enum http-method { GET, PUT, POST, DELETE }
 
-    page: func(e: event, cred: dict) -> result<edgee-request, string>;
-    track: func(e: event, cred: dict) -> result<edgee-request, string>;
-    user: func(e: event, cred:dict) -> result<edgee-request, string>;
+    page: func(e: event, settings: dict) -> result<edgee-request, string>;
+    track: func(e: event, settings: dict) -> result<edgee-request, string>;
+    user: func(e: event, settings:dict) -> result<edgee-request, string>;
 }


### PR DESCRIPTION
New wit protocol

- `edgee-request` has now a new field `forward-client-headers`
- change `credentials` with `settings`
- Adapt Readme to reflect latest toml changes