### PR TITLE
Fix build command to handle hardlink issue on Linux

### DIFF
--- a/edgee-component.toml
+++ b/edgee-component.toml
@@ -19,7 +19,7 @@ icon-path = "segment.png"
 language = "Rust"
 
 [component.build]
-command = "cargo build --target wasm32-wasip2 --release && cp ./target/wasm32-wasip2/release/segment_component.wasm segment.wasm"
+command = "cargo build --target wasm32-wasip2 --release && rm -f segment.wasm && cp ./target/wasm32-wasip2/release/segment_component.wasm segment.wasm"
 output_path = "segment.wasm"
 
 [component.settings.segment_project_id]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,10 +143,10 @@ fn build_edgee_request(segment_payload: SegmentPayload, settings: &Dict) -> Edge
         .get("segment_write_key")
         .unwrap_or(&String::new())
         .to_owned();
-    let key = GeneralPurpose::new(&STANDARD, PAD).encode(format!("{}:", key));
+    let key = GeneralPurpose::new(&STANDARD, PAD).encode(format!("{key}:"));
 
     let mut headers = vec![];
-    headers.push((String::from("authorization"), format!("Basic {}", key)));
+    headers.push((String::from("authorization"), format!("Basic {key}")));
     headers.push((
         String::from("content-type"),
         String::from("application/json"),


### PR DESCRIPTION
## Summary
- Add `rm -f [output_file]` before `mv`/`cp` operations in build commands
- Prevents "cannot move file to itself" errors on Linux where output WASM file is already a hardlink